### PR TITLE
Make create and import wallet work again

### DIFF
--- a/src/SimpleApp.js
+++ b/src/SimpleApp.js
@@ -23,20 +23,9 @@ const mapStateToProps = state => {
   }
 }
 
-const mapDispatchToProps = dispatch => {
-  return {    
-    setWallet: (mnemonic) => { 
-        dispatch({ type: 'SET_WALLET', wallet: mnemonic })
-    },
-    setAccount: (account) => { 
-        dispatch({ type: 'SET_ACCOUNT', account: account })    
-    }
-  }
-}
-
 const SimpleApp = connect(
     mapStateToProps,
-    mapDispatchToProps
+    null
 )(SimpleAppNav)
 
 export default SimpleApp;

--- a/src/Wallet/Create.js
+++ b/src/Wallet/Create.js
@@ -4,9 +4,9 @@ import { Alert, StyleSheet, Text, View, TextInput } from 'react-native';
 import { StackNavigator } from 'react-navigation';
 import { Button, Card, ListItem } from 'react-native-elements';
 import { setWallet } from '../actions';
+import bip39 from 'react-native-bip39';
 
 const hdKey = require('ethereumjs-wallet/hdkey');
-const bip39 = require('bip39');
 
 const MINIMUM_PASSWORD_LENGTH = 8;
 
@@ -19,7 +19,7 @@ class Create extends React.Component {
   }
 
   async componentWillMount() {
-    let mnemonic = bip39.generateMnemonic();
+    let mnemonic = await bip39.generateMnemonic();
     this.setState({mnemonic});
   }
 

--- a/src/Wallet/Create.js
+++ b/src/Wallet/Create.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Alert, StyleSheet, Text, View, TextInput } from 'react-native';
 import { StackNavigator } from 'react-navigation';
 import { Button, Card, ListItem } from 'react-native-elements';
+import { setWallet } from '../actions';
 
 const hdKey = require('ethereumjs-wallet/hdkey');
 const bip39 = require('bip39');
 
 const MINIMUM_PASSWORD_LENGTH = 8;
 
-export default class Create extends React.Component {
-
+class Create extends React.Component {
   constructor(props) {
     super(props);
     this.state = { mnemonic: '' }
@@ -24,7 +25,8 @@ export default class Create extends React.Component {
 
   createWallet() {
     let mnemonic = this.state.mnemonic;
-    this.props.screenProps.setWallet(mnemonic);
+
+    this.props.setWallet(mnemonic);
     this.props.navigation.navigate('Main');
   }
 
@@ -45,3 +47,12 @@ export default class Create extends React.Component {
     );
   }
 }
+
+const mapDispatchToProps = {
+  setWallet
+};
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(Create);

--- a/src/Wallet/Import.js
+++ b/src/Wallet/Import.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import getWeb3 from '../utils/getWeb3'
 import { Text, View, TextInput, Button, Modal } from 'react-native';
 import Web3 from 'web3';
 import { StackNavigator } from 'react-navigation';
+import { setWallet } from '../actions';
 
-export default class Import extends React.Component {
+class Import extends React.Component {
   constructor(props) {
     super(props);
 
@@ -21,7 +23,7 @@ export default class Import extends React.Component {
   onPressImport() {
     // Import Wallet
     let mnemonic = this.state.mnemonic;
-    this.props.screenProps.setWallet(mnemonic);
+    this.props.setWallet(mnemonic);
 
     // Navigate to Wallet screen
     this.props.navigation.navigate('Main');
@@ -47,3 +49,12 @@ export default class Import extends React.Component {
     );
   }
 }
+
+const mapDispatchToProps = {
+  setWallet
+};
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(Import);

--- a/src/actions.js
+++ b/src/actions.js
@@ -108,3 +108,10 @@ export const getTransactions = (address) => {
             });      
     }
 }
+
+export const setWallet = (mnemonic) => {
+  return {
+      type: 'SET_WALLET',
+      wallet: mnemonic
+  };
+}


### PR DESCRIPTION
This PR contains two things:

1. It was using the package `bip39` instead of `react-native-bip39`. This was doing that `randombytes` was not found since the `bip39` use the `randombytes` from node and the `react-native-bip39` uses the imported `react-native-randombytes`.

Because of this, the wallet was failing on the creation of a mnemonic with the error: `secure random number generation not supported by this browser`.

It worked when the debugger was connected, but it didn't without it.

2. The action `createWallet` was not in the props of the component `Create` neither in the `Import` one. This is because the react-navigation does not propagate dispatching props for the components in the stack navigation. This connect the two components `Create` and `Import` to the `createWallet` dispatch action.